### PR TITLE
Make erlangHome optional - fallback to system's default

### DIFF
--- a/lib/alchemide/wrapper.coffee
+++ b/lib/alchemide/wrapper.coffee
@@ -31,13 +31,15 @@ exports.init = (pP) ->
   #line 1  #line 2
 
   erlPath = atom.config.get("#{name}.erlangHome").trim()
-  if !erlPath
-    atom.notifications.addError('Erlang home configuration setting missing')
+  env = if erlPath
+      extend({
+        ERL_HOME: erlPath,
+        ERL_PATH: path.join(erlPath, 'erl')
+      }, process.env)
+  else
+      process.env
   options = {
-    env: extend({
-      ERL_HOME: erlPath,
-      ERL_PATH: path.join(erlPath, 'erl')
-    }, process.env)
+    env: env
   }
 
   console.log(setting)


### PR DESCRIPTION
**Problem:**
autocomplete-elixir should be it's best effort to work out-of-the-box without any configuration

**Solution:**
If we don't have erlangHome present, just leave it unspecified to allow system's default Erlang to take over.