### PR TITLE
fix for #166 Uncaught TypeError

### DIFF
--- a/lib/alchemide/doendmatcher.coffee
+++ b/lib/alchemide/doendmatcher.coffee
@@ -14,7 +14,7 @@ module.exports.handleMatch = (editor, e) ->
   if not atom.config.get("autocomplete-elixir.matchDoEnd") then return
   decorations.map (a) -> a.destroy()
 
-  lastLineNo = editor.buffer.lines.length - 1
+  lastLineNo = editor.buffer.getLines().length - 1
   [x, y] = e.cursor.getBufferPosition().toArray()
   fromBeginning = new Range([0,0], [x, y-1])
   toEnd         = new Range([x, y+1], [lastLineNo, 0])


### PR DESCRIPTION
`editor.buffer.lines` to `editor.buffer.getLines()`
https://atom.io/docs/api/v1.6.0/TextBuffer#instance-getLines

fix
#85 #92 #95 #96 #97 #98 #99 #100 #101 #102 #103 #104 #105 #107 #108 #109 #111 #112 #113 #115 #117 #120 #121 #122 #123 #124 #125 #127 #128 #129 #130 #131 #132 #133 #134 #135 #136 #137 #138 #139 #140 #141 #142 #143 #144 #145 #146 #149 #150 #151 #152 #153 #154 #155 #156 #158 #159 #160 #161 #162 #163 #165 #166 