### PR TITLE
Remove duplicate key 'spawn'

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -37,9 +37,6 @@
     'body': 'spawn(fn ->\n\t$1\nend)'
   'spawn_link' :
     'prefix' : 'spawn'
-    'body': 'spawn(fn ->\n\t$1\nend)'
-  'spawn' :
-    'prefix' : 'spawn'
     'body': 'spawn_link(fn ->\n\t$1\nend)'
   'Agent start' :
     'prefix' : 'Agent.start'


### PR DESCRIPTION
Atom gives an error every time the package loads with: `/Users/abcdef/.atom/packages/autocomplete-elixir/snippets/language-elixir.cson: Duplicate key 'spawn'`